### PR TITLE
feat: add neon world clock overlay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1054,4 +1054,7 @@ After completing a task, agents self-evaluate in `AGENTS.md` and append reflecti
 ### Codex Agent Reflection (2025-08-22 01:21 UTC)
 - Moved World Clock widgets into a global overlay so selected zones display across the dashboard.
 - Confirmed lint and tests pass with `pnpm run lint` and `pnpm test`.
-- 
+
+### Codex Agent Reflection (2025-08-22 14:34 UTC)
+- Styled World Clock overlay with neon-glass effects for a futuristic feel.
+- Verified repository passes lint and tests with `pnpm run lint` and `pnpm test`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to **ZenzaScheduler OS Life Scheduler** are documented in th
 - Tools menu now offers a GED Calculator accessible from any dashboard tab (2025-08-22 00:55 UTC)
 - World Clock widgets display across all dashboard screens and overlays (2025-08-22 01:21:14 UTC)
 ### Changed
+- World Clock overlay glows with neon glass styling for a futuristic feel (2025-08-22 14:34:06 UTC)
 - Wedding Vows module shows Rumi's writing date while Khen's remains to be revealed (2025-08-21 20:35:00 UTC)
 - Soundboard default sounds now download from remote URLs instead of bundling audio files (2025-08-19 03:38:51 UTC)
 - Soundboard upgraded to a 12-pad grid with keyboard shortcuts and removable custom clips (2025-08-19 04:50:00 UTC)

--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,7 @@ ZenzaScheduler OS — TODO
 - Darkened Learning Notes heading and cards for better readability
 - Tools menu now offers a GED Calculator accessible from any dashboard tab
 - World Clock widgets display on every dashboard screen, even above overlays
+- World Clock overlay now glows with neon glass styling for a futuristic feel
 
 Backlog
 - Add E2E test harness (Playwright) for layout assertions

--- a/zenzalife-scheduler/public/CHANGELOG.md
+++ b/zenzalife-scheduler/public/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to **ZenzaScheduler OS Life Scheduler** are documented in th
 - Learning Notes module lets users jot down study notes for any subject (2025-08-21 20:35:27 UTC)
 - World Clock widgets display across all dashboard screens and overlays (2025-08-22 01:21:14 UTC)
 ### Changed
+- World Clock overlay glows with neon glass styling for a futuristic feel (2025-08-22 14:34:06 UTC)
 - Wedding Vows module shows Rumi's writing date while Khen's remains to be revealed (2025-08-21 20:35:00 UTC)
 - Soundboard default sounds now download from remote URLs instead of bundling audio files (2025-08-19 03:38:51 UTC)
 - Soundboard upgraded to a 12-pad grid with keyboard shortcuts and removable custom clips (2025-08-19 04:50:00 UTC)

--- a/zenzalife-scheduler/src/components/WorldClockOverlay.tsx
+++ b/zenzalife-scheduler/src/components/WorldClockOverlay.tsx
@@ -139,7 +139,7 @@ export function WorldClockOverlay() {
           createPortal(
             <div
               key={zone.id}
-              className="fixed z-[1000] cursor-move bg-black/50 text-white text-xs px-2 py-1 rounded"
+              className="fixed z-[1000] cursor-move rounded-full border border-cyan-400/50 bg-gradient-to-br from-transparent via-cyan-500/20 to-purple-500/20 backdrop-blur-md text-cyan-100 font-mono text-xs px-3 py-2 shadow-[0_0_10px_rgba(0,255,255,0.7)]"
               style={{ top: zone.pos_y, left: zone.pos_x }}
               onMouseDown={e => startDrag(e, zone.id)}
               onContextMenu={e => handleContextMenu(e, zone.id)}
@@ -152,7 +152,7 @@ export function WorldClockOverlay() {
       {contextMenu.visible &&
         createPortal(
           <div
-            className="fixed z-[1000] p-4 rounded-xl harold-sky bg-gradient-to-br from-indigo-950 via-purple-950 to-blue-900 text-purple-100 shadow-lg"
+            className="fixed z-[1000] p-4 rounded-xl border border-cyan-500/30 bg-gradient-to-br from-gray-900/80 via-indigo-900/80 to-purple-900/80 backdrop-blur-xl text-cyan-100 shadow-[0_0_15px_rgba(0,255,255,0.4)]"
             style={{ top: contextMenu.y, left: contextMenu.x }}
             onClick={e => e.stopPropagation()}
           >


### PR DESCRIPTION
## Summary
- restyle world clock overlay with neon glass glow for a futuristic feel
- document neon overlay in changelog and task list

## Testing
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a87fa2dec08327889348bc3ac24f48