### PR TITLE
feat: mean overlay for Learning Notes and GED calculator typing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1054,4 +1054,11 @@ After completing a task, agents self-evaluate in `AGENTS.md` and append reflecti
 ### Codex Agent Reflection (2025-08-22 01:21 UTC)
 - Moved World Clock widgets into a global overlay so selected zones display across the dashboard.
 - Confirmed lint and tests pass with `pnpm run lint` and `pnpm test`.
-- 
+
+### Codex Agent Reflection (2025-08-22 14:28 UTC)
+- Showed sum and mean for selected numbers in Learning Notes with a context overlay.
+- Allowed GED Calculator to accept keyboard input for numbers and symbols.
+
+### Codex Agent Reflection (2025-08-22 16:20 UTC)
+- Corrected Learning Notes mean overlay positioning and hid it on scroll so it no longer floats far from the selection.
+- Verified repository passes lint and tests with `pnpm run lint` and `pnpm test`.

--- a/TODO.md
+++ b/TODO.md
@@ -35,6 +35,10 @@ ZenzaScheduler OS — TODO
 - Tools menu now offers a GED Calculator accessible from any dashboard tab
 - World Clock widgets display on every dashboard screen, even above overlays
 
+- Learning Notes selection shows sum and mean for highlighted numbers
+- GED Calculator accepts keyboard input for numbers and symbols
+- Mean overlay positions near selected numbers and disappears when scrolling
+
 Backlog
 - Add E2E test harness (Playwright) for layout assertions
 - Accessibility pass for floating buttons and modals

--- a/zenzalife-scheduler/src/components/dashboard/GEDCalculator.tsx
+++ b/zenzalife-scheduler/src/components/dashboard/GEDCalculator.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { X } from 'lucide-react'
 import { supabase, getCurrentUser } from '@/lib/supabase'
 
@@ -39,7 +39,7 @@ export function GEDCalculator({ onClose }: GEDCalculatorProps) {
     }
   }
 
-  const handleSolve = async () => {
+  const handleSolve = useCallback(async () => {
     try {
       const prepared = input
         .replace(/√/g, 'Math.sqrt')
@@ -65,7 +65,33 @@ export function GEDCalculator({ onClose }: GEDCalculatorProps) {
     } catch {
       setResult('Error')
     }
-  }
+  }, [history, input])
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (/^[0-9]$/.test(e.key)) {
+        setInput((prev) => prev + e.key)
+        setResult(null)
+      } else if (['+', '-', '(', ')', '^', '.'].includes(e.key)) {
+        setInput((prev) => prev + e.key)
+        setResult(null)
+      } else if (e.key === '*') {
+        setInput((prev) => prev + '×')
+        setResult(null)
+      } else if (e.key === '/') {
+        setInput((prev) => prev + '÷')
+        setResult(null)
+      } else if (e.key === 'Backspace') {
+        setInput((prev) => prev.slice(0, -1))
+        setResult(null)
+      } else if (e.key === 'Enter') {
+        e.preventDefault()
+        void handleSolve()
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [handleSolve])
 
   const rows = [
     ['7', '8', '9', '÷'],

--- a/zenzalife-scheduler/src/components/dashboard/LearningNotesModule.tsx
+++ b/zenzalife-scheduler/src/components/dashboard/LearningNotesModule.tsx
@@ -4,6 +4,7 @@ import { supabase, LearningNote } from '@/lib/supabase'
 import dayjs from 'dayjs'
 import { Plus, NotebookText, Pencil, Trash2 } from 'lucide-react'
 import { toast } from 'react-hot-toast'
+import { SelectionMeanOverlay } from './SelectionMeanOverlay'
 
 export function LearningNotesModule() {
   const { user } = useAuth()
@@ -209,6 +210,7 @@ export function LearningNotesModule() {
           </div>
         </div>
       )}
+      <SelectionMeanOverlay />
     </div>
   )
 }

--- a/zenzalife-scheduler/src/components/dashboard/SelectionMeanOverlay.tsx
+++ b/zenzalife-scheduler/src/components/dashboard/SelectionMeanOverlay.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+interface MeanState {
+  sum: number
+  mean: number
+  count: number
+  rect: DOMRect
+}
+
+export function SelectionMeanOverlay() {
+  const [state, setState] = useState<MeanState | null>(null)
+
+  useEffect(() => {
+    const handleMouseUp = () => {
+      const sel = window.getSelection()
+      if (!sel || sel.isCollapsed) {
+        setState(null)
+        return
+      }
+      const text = sel.toString().trim()
+      if (!text || /[^0-9+.\s-]/.test(text)) {
+        setState(null)
+        return
+      }
+      const nums = text.match(/-?\d+(?:\.\d+)?/g)
+      if (!nums || nums.length < 2) {
+        setState(null)
+        return
+      }
+      const values = nums.map((n) => parseFloat(n))
+      const sum = values.reduce((a, b) => a + b, 0)
+      const count = values.length
+      const mean = sum / count
+      const rect = sel.getRangeAt(0).getBoundingClientRect()
+      setState({ sum, mean, count, rect })
+    }
+    const handleScroll = () => setState(null)
+    document.addEventListener('mouseup', handleMouseUp)
+    window.addEventListener('scroll', handleScroll)
+    return () => {
+      document.removeEventListener('mouseup', handleMouseUp)
+      window.removeEventListener('scroll', handleScroll)
+    }
+  }, [])
+
+  if (!state) return null
+
+  const style = {
+    position: 'absolute' as const,
+    top: state.rect.bottom + window.scrollY + 8,
+    left: state.rect.left + window.scrollX
+  }
+
+  return createPortal(
+    <div
+      style={style}
+      className="z-50 harold-sky bg-purple-950 border-2 border-purple-400 rounded p-2 text-sm text-white space-y-1"
+    >
+      <div>Sum: {state.sum}</div>
+      <div>
+        Mean (÷{state.count}): {Number.isFinite(state.mean) ? state.mean : ''}
+      </div>
+      <button
+        className="btn-secondary mt-1 w-full text-xs"
+        onClick={() => setState(null)}
+      >
+        Close
+      </button>
+    </div>,
+    document.body
+  )
+}
+
+export default SelectionMeanOverlay


### PR DESCRIPTION
## Summary
- show sum and mean in a context overlay when selecting numbers in Learning Notes
- allow GED Calculator to accept keyboard input for numbers and symbols
- position mean overlay next to selection and dismiss on scroll

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a87db0564883278f8cd718e29c3f34