### PR TITLE
style(WorldClockOverlay): apply neon gradient for futuristic look

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1054,4 +1054,8 @@ After completing a task, agents self-evaluate in `AGENTS.md` and append reflecti
 ### Codex Agent Reflection (2025-08-22 01:21 UTC)
 - Moved World Clock widgets into a global overlay so selected zones display across the dashboard.
 - Confirmed lint and tests pass with `pnpm run lint` and `pnpm test`.
+
+### Codex Agent Reflection (2025-08-22 14:34 UTC)
+- Styled the World Clock overlay with a neon gradient, blur, and monospace glow for a futuristic aesthetic.
+- Verified repository passes lint with `pnpm run lint` and tests with `pnpm test`.
 - 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to **ZenzaScheduler OS Life Scheduler** are documented in th
 - Tools menu now offers a GED Calculator accessible from any dashboard tab (2025-08-22 00:55 UTC)
 - World Clock widgets display across all dashboard screens and overlays (2025-08-22 01:21:14 UTC)
 ### Changed
+- World Clock overlay now glows with a neon gradient for a futuristic feel (2025-08-22 14:34 UTC)
 - Wedding Vows module shows Rumi's writing date while Khen's remains to be revealed (2025-08-21 20:35:00 UTC)
 - Soundboard default sounds now download from remote URLs instead of bundling audio files (2025-08-19 03:38:51 UTC)
 - Soundboard upgraded to a 12-pad grid with keyboard shortcuts and removable custom clips (2025-08-19 04:50:00 UTC)

--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,7 @@ ZenzaScheduler OS — TODO
 - Darkened Learning Notes heading and cards for better readability
 - Tools menu now offers a GED Calculator accessible from any dashboard tab
 - World Clock widgets display on every dashboard screen, even above overlays
+- World Clock overlay glows with a neon gradient for a futuristic feel
 
 Backlog
 - Add E2E test harness (Playwright) for layout assertions

--- a/zenzalife-scheduler/public/CHANGELOG.md
+++ b/zenzalife-scheduler/public/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to **ZenzaScheduler OS Life Scheduler** are documented in th
 - Learning Notes module lets users jot down study notes for any subject (2025-08-21 20:35:27 UTC)
 - World Clock widgets display across all dashboard screens and overlays (2025-08-22 01:21:14 UTC)
 ### Changed
+- World Clock overlay now glows with a neon gradient for a futuristic feel (2025-08-22 14:34 UTC)
 - Wedding Vows module shows Rumi's writing date while Khen's remains to be revealed (2025-08-21 20:35:00 UTC)
 - Soundboard default sounds now download from remote URLs instead of bundling audio files (2025-08-19 03:38:51 UTC)
 - Soundboard upgraded to a 12-pad grid with keyboard shortcuts and removable custom clips (2025-08-19 04:50:00 UTC)

--- a/zenzalife-scheduler/src/components/WorldClockOverlay.tsx
+++ b/zenzalife-scheduler/src/components/WorldClockOverlay.tsx
@@ -139,7 +139,7 @@ export function WorldClockOverlay() {
           createPortal(
             <div
               key={zone.id}
-              className="fixed z-[1000] cursor-move bg-black/50 text-white text-xs px-2 py-1 rounded"
+              className="fixed z-[1000] cursor-move rounded-lg px-3 py-2 text-xs font-mono tracking-wider text-cyan-100 bg-gradient-to-br from-sky-900/80 via-indigo-900/80 to-purple-900/80 border border-cyan-400/30 shadow-lg backdrop-blur-sm"
               style={{ top: zone.pos_y, left: zone.pos_x }}
               onMouseDown={e => startDrag(e, zone.id)}
               onContextMenu={e => handleContextMenu(e, zone.id)}
@@ -152,7 +152,7 @@ export function WorldClockOverlay() {
       {contextMenu.visible &&
         createPortal(
           <div
-            className="fixed z-[1000] p-4 rounded-xl harold-sky bg-gradient-to-br from-indigo-950 via-purple-950 to-blue-900 text-purple-100 shadow-lg"
+            className="fixed z-[1000] p-4 rounded-xl border border-cyan-400/40 bg-gradient-to-br from-sky-900/95 via-indigo-950/95 to-purple-950/95 text-cyan-100 shadow-lg backdrop-blur-sm font-mono tracking-wider"
             style={{ top: contextMenu.y, left: contextMenu.x }}
             onClick={e => e.stopPropagation()}
           >


### PR DESCRIPTION
## Summary
- give World Clock overlay a neon gradient, border, and blur for a futuristic vibe
- document the styling change in changelog and TODO

## Testing
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a87fa2dec08327889348bc3ac24f48