### PR TITLE
fix: keep world clock timezone search visible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1079,3 +1079,7 @@ After completing a task, agents self-evaluate in `AGENTS.md` and append reflecti
 ### Codex Agent Reflection (2025-08-22 15:52 UTC)
 - Removed failing ensure-learning-notes-schema edge function call so Learning Notes no longer triggers CORS errors.
 - Verified repository passes lint with `pnpm run lint`.
+
+### Codex Agent Reflection (2025-08-22 17:10 UTC)
+- Raised World Clock timezone search dropdown z-index so options display above overlay widgets.
+- Verified repository passes lint with `pnpm run lint`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ All notable changes to **ZenzaScheduler OS Life Scheduler** are documented in th
 - IDE plus button opens a Harold and the Purple Crayon & Vanilla Sky filename window, and double-click renaming uses the same modal instead of a browser prompt (2025-08-02 02:49 UTC)
 - Learning Notes heading and cards darkened for higher contrast and easier reading (2025-08-21 22:11 UTC)
 ### Fixed
+- World Clock timezone search dropdown now appears above widgets so options aren't hidden when adding new zones (2025-08-22 17:10 UTC)
 - Removed call to failing `ensure-learning-notes-schema` Supabase function to avoid CORS errors during Learning Notes load (2025-08-22 15:52 UTC)
 - Learning Notes cards no longer render white text on white backgrounds by moving custom classes into the Tailwind components layer (2025-08-21 21:34:43 UTC)
 - Removed call to missing `ensure-todo-status` Supabase function to avoid CORS errors during to-do list initialization (2025-08-19 05:40:18 UTC)

--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,7 @@ ZenzaScheduler OS — TODO
 - World Clock widgets display on every dashboard screen, even above overlays
 - World Clock overlay glows with a neon gradient for a futuristic feel
 - World Clock overlay now glows with neon glass styling for a futuristic feel
+- Timezone dropdown renders above World Clock widgets so search results stay visible
 
 - Learning Notes selection shows sum and mean for highlighted numbers
 - GED Calculator accepts keyboard input for numbers and symbols

--- a/zenzalife-scheduler/public/CHANGELOG.md
+++ b/zenzalife-scheduler/public/CHANGELOG.md
@@ -68,6 +68,7 @@ All notable changes to **ZenzaScheduler OS Life Scheduler** are documented in th
 - IDE plus button opens a Harold and the Purple Crayon & Vanilla Sky filename window, and double-click renaming uses the same modal instead of a browser prompt (2025-08-02 02:49 UTC)
 - Learning Notes heading and cards darkened for higher contrast and easier reading (2025-08-21 22:11 UTC)
 ### Fixed
+- World Clock timezone search dropdown now appears above widgets so options aren't hidden when adding new zones (2025-08-22 17:10 UTC)
 - Removed call to failing `ensure-learning-notes-schema` Supabase function to avoid CORS errors during Learning Notes load (2025-08-22 15:52 UTC)
 - Learning Notes cards no longer render white text on white backgrounds by moving custom classes into the Tailwind components layer (2025-08-21 21:34:43 UTC)
 - Removed call to missing `ensure-todo-status` Supabase function to avoid CORS errors during to-do list initialization (2025-08-19 05:40:18 UTC)

--- a/zenzalife-scheduler/src/components/dashboard/ClockModule.tsx
+++ b/zenzalife-scheduler/src/components/dashboard/ClockModule.tsx
@@ -832,7 +832,7 @@ export function ClockModule() {
                 className="input-dreamy w-full"
               />
               {showZoneList && zoneInput && (
-                <ul className="absolute left-0 right-0 mt-1 max-h-60 overflow-auto card-floating bg-gradient-to-br from-purple-900/90 via-indigo-900/90 to-blue-900/90 text-purple-100 text-left">
+                <ul className="absolute left-0 right-0 mt-1 max-h-60 overflow-auto z-[2000] card-floating bg-gradient-to-br from-purple-900/90 via-indigo-900/90 to-blue-900/90 text-purple-100 text-left">
                   {filteredZones.map(tz => (
                     <li
                       key={tz}


### PR DESCRIPTION
## Summary
- prevent World Clock timezone results from being hidden behind overlay widgets

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa4dbaa23c83279c24b50b25aa2c81