### PR TITLE
Fix 10-Year Self Letter saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ All notable changes to **ZenzaScheduler OS Life Scheduler** are documented in th
 - IDE plus button opens a Harold and the Purple Crayon & Vanilla Sky filename window, and double-click renaming uses the same modal instead of a browser prompt (2025-08-02 02:49 UTC)
 - Learning Notes heading and cards darkened for higher contrast and easier reading (2025-08-21 22:11 UTC)
 ### Fixed
+- Saving the 10-Year Self Letter no longer fails with an undefined error by adding a unique user constraint to `self_letters` (2025-08-25 19:44:02 UTC)
 - World Clock timezone search dropdown now appears above widgets so options aren't hidden when adding new zones (2025-08-22 17:10 UTC)
 - Removed call to failing `ensure-learning-notes-schema` Supabase function to avoid CORS errors during Learning Notes load (2025-08-22 15:52 UTC)
 - Learning Notes cards no longer render white text on white backgrounds by moving custom classes into the Tailwind components layer (2025-08-21 21:34:43 UTC)

--- a/TODO.md
+++ b/TODO.md
@@ -48,6 +48,7 @@ ZenzaScheduler OS — TODO
 
 - Added 10-Year Self Letter module for writing a letter to your future self
 - 10-Year Self Letter can be edited and saved for future reflection
+- Saving the 10-Year Self Letter no longer fails with an undefined error by adding a unique user constraint
 
 Backlog
 - Add E2E test harness (Playwright) for layout assertions

--- a/supabase/functions/ensure-self-letter-schema/index.ts
+++ b/supabase/functions/ensure-self-letter-schema/index.ts
@@ -31,7 +31,8 @@ Deno.serve(async (req) => {
   content text NOT NULL,
   created_at timestamptz DEFAULT now(),
   updated_at timestamptz DEFAULT now()
-);`,
+);
+CREATE UNIQUE INDEX IF NOT EXISTS self_letters_user_id_key ON public.self_letters(user_id);`,
       }),
     })
 

--- a/supabase/tables/self_letters.sql
+++ b/supabase/tables/self_letters.sql
@@ -5,3 +5,5 @@ CREATE TABLE IF NOT EXISTS public.self_letters (
   created_at timestamptz DEFAULT now(),
   updated_at timestamptz DEFAULT now()
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS self_letters_user_id_key ON public.self_letters(user_id);

--- a/zenzalife-scheduler/public/CHANGELOG.md
+++ b/zenzalife-scheduler/public/CHANGELOG.md
@@ -70,6 +70,7 @@ All notable changes to **ZenzaScheduler OS Life Scheduler** are documented in th
 - IDE plus button opens a Harold and the Purple Crayon & Vanilla Sky filename window, and double-click renaming uses the same modal instead of a browser prompt (2025-08-02 02:49 UTC)
 - Learning Notes heading and cards darkened for higher contrast and easier reading (2025-08-21 22:11 UTC)
 ### Fixed
+- Saving the 10-Year Self Letter no longer fails with an undefined error by adding a unique user constraint to `self_letters` (2025-08-25 19:44:02 UTC)
 - World Clock timezone search dropdown now appears above widgets so options aren't hidden when adding new zones (2025-08-22 17:10 UTC)
 - Removed call to failing `ensure-learning-notes-schema` Supabase function to avoid CORS errors during Learning Notes load (2025-08-22 15:52 UTC)
 - Learning Notes cards no longer render white text on white backgrounds by moving custom classes into the Tailwind components layer (2025-08-21 21:34:43 UTC)

--- a/zenzalife-scheduler/src/components/dashboard/TenYearSelfLetterModule.tsx
+++ b/zenzalife-scheduler/src/components/dashboard/TenYearSelfLetterModule.tsx
@@ -55,13 +55,13 @@ Your Past Self`
         {
           user_id: user.id,
           content: draft,
-          created_at: new Date().toISOString(),
           updated_at: new Date().toISOString(),
         },
         { onConflict: 'user_id' }
       )
     if (error) {
-      toast.error('Failed to save letter: ' + error.message)
+      console.error('Failed to save letter', error)
+      toast.error('Failed to save letter: ' + (error.message ?? 'Unknown error'))
     } else {
       setLetter(draft)
       setEditing(false)


### PR DESCRIPTION
## Summary
- ensure self_letters table enforces one letter per user with a unique index
- update 10-Year Self Letter module to upsert without created_at and show clearer errors
- document fix in changelog and TODO

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acbc6034508327a07e495f6d9da030