### PR TITLE
feat: add social sharing to wedding vows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1087,3 +1087,7 @@ After completing a task, agents self-evaluate in `AGENTS.md` and append reflecti
 ### Codex Agent Reflection (2025-08-24 22:36 UTC)
 - Added 10-Year Self Letter module with dashboard navigation.
 - Verified repository passes lint with `pnpm run lint`.
+
+### Codex Agent Reflection (2025-08-25 20:28 UTC)
+- Styled Wedding Vows module with cards for each vow and embedded share buttons.
+- Verified repository passes lint with `pnpm run lint`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to **ZenzaScheduler OS Life Scheduler** are documented in th
 - Learning Notes module lets users jot down study notes for any subject (2025-08-21 20:35:27 UTC)
 - 10-Year Self Letter module shares a reflective note to your future self (2025-08-24 22:36:51 UTC)
 - 10-Year Self Letter module allows editing and saves updates with Supabase (2025-08-24 23:04:25 UTC)
+- Wedding Vows module adds social share buttons for popular networks and displays each vow in a styled card (2025-08-25 19:45:44 UTC)
 - Review link utilities support deletion, duration changes, and expiration messages (2025-08-21 21:45:53 UTC)
 - Tools menu now offers a GED Calculator accessible from any dashboard tab (2025-08-22 00:55 UTC)
 - World Clock widgets display across all dashboard screens and overlays (2025-08-22 01:21:14 UTC)

--- a/TODO.md
+++ b/TODO.md
@@ -28,6 +28,7 @@ ZenzaScheduler OS — TODO
 - Added English/Bisaya translation toggle for Wedding Vows module
 - Displayed wedding vow writing date in Wedding Vows module
 - Showed Rumi's vow writing date and kept Khen's to be revealed
+- Wedding Vows can be shared across social networks with dedicated share buttons, and each vow appears in a styled card
 - Added Learning Notes module for capturing study notes
 - Fixed Learning Notes card backgrounds so note text remains visible without highlighting
 - Review links can be deleted, duration updated, and display time until expiration

--- a/zenzalife-scheduler/public/CHANGELOG.md
+++ b/zenzalife-scheduler/public/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to **ZenzaScheduler OS Life Scheduler** are documented in th
 - Learning Notes module lets users jot down study notes for any subject (2025-08-21 20:35:27 UTC)
 - 10-Year Self Letter module shares a reflective note to your future self (2025-08-24 22:36:51 UTC)
 - 10-Year Self Letter module allows editing and saves updates with Supabase (2025-08-24 23:04:25 UTC)
+- Wedding Vows module adds social share buttons for popular networks and displays each vow in a styled card (2025-08-25 19:45:44 UTC)
 - Review link utilities support deletion, duration changes, and expiration messages (2025-08-21 21:45:53 UTC)
 - Tools menu now offers a GED Calculator accessible from any dashboard tab (2025-08-22 00:55 UTC)
 - World Clock widgets display across all dashboard screens and overlays (2025-08-22 01:21:14 UTC)

--- a/zenzalife-scheduler/src/components/dashboard/WeddingVowsModule.tsx
+++ b/zenzalife-scheduler/src/components/dashboard/WeddingVowsModule.tsx
@@ -1,5 +1,14 @@
 import React from 'react'
-import { Flower2 } from 'lucide-react'
+import {
+  Flower2,
+  Share2,
+  Facebook,
+  Twitter,
+  Linkedin,
+  MessageCircle,
+  Send,
+  Link as LinkIcon,
+} from 'lucide-react'
 
 export function WeddingVowsModule() {
   const [isBisaya, setIsBisaya] = React.useState(false)
@@ -57,6 +66,126 @@ Gihigugma tika pag-ayo, hangtod sa walay katapusan, baby—karon, kanunay, ug ha
   const khenDateEnglish = 'Writing date to be revealed…'
   const khenDateBisaya = 'Ipadayag pa ang petsa sa pagsulat…'
 
+  function ShareButtons({ text }: { text: string }) {
+    const url = typeof window !== 'undefined' ? window.location.href : ''
+    const encodedUrl = encodeURIComponent(url)
+    const encodedText = encodeURIComponent(text)
+
+    const open = (shareUrl: string) => {
+      window.open(shareUrl, '_blank', 'width=600,height=400')
+    }
+
+    const handleNativeShare = async () => {
+      if (typeof navigator !== 'undefined' && navigator.share) {
+        try {
+          await navigator.share({ title: 'Our Wedding Vows', text, url })
+        } catch {
+          // ignore
+        }
+      }
+    }
+
+    const handleCopy = async () => {
+      if (typeof navigator !== 'undefined' && navigator.clipboard) {
+        try {
+          await navigator.clipboard.writeText(`${text}\n\n${url}`)
+        } catch {
+          // ignore
+        }
+      }
+    }
+
+    return (
+      <div className="flex gap-4 text-rose-600">
+        <button aria-label="Share" onClick={handleNativeShare}>
+          <Share2 className="w-5 h-5" />
+        </button>
+        <button
+          aria-label="Share on Facebook"
+          onClick={() =>
+            open(
+              `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedText}`,
+            )
+          }
+        >
+          <Facebook className="w-5 h-5" />
+        </button>
+        <button
+          aria-label="Share on X"
+          onClick={() =>
+            open(
+              `https://twitter.com/intent/tweet?text=${encodedText}&url=${encodedUrl}`,
+            )
+          }
+        >
+          <Twitter className="w-5 h-5" />
+        </button>
+        <button
+          aria-label="Share on LinkedIn"
+          onClick={() =>
+            open(
+              `https://www.linkedin.com/shareArticle?mini=true&url=${encodedUrl}&title=${encodedText}`,
+            )
+          }
+        >
+          <Linkedin className="w-5 h-5" />
+        </button>
+        <button
+          aria-label="Share on WhatsApp"
+          onClick={() =>
+            open(
+              `https://api.whatsapp.com/send?text=${encodedText}%20${encodedUrl}`,
+            )
+          }
+        >
+          <MessageCircle className="w-5 h-5" />
+        </button>
+        <button
+          aria-label="Share on Telegram"
+          onClick={() =>
+            open(`https://t.me/share/url?url=${encodedUrl}&text=${encodedText}`)
+          }
+        >
+          <Send className="w-5 h-5" />
+        </button>
+        <button aria-label="Copy link" onClick={handleCopy}>
+          <LinkIcon className="w-5 h-5" />
+        </button>
+      </div>
+    )
+  }
+
+  function VowCard({
+    title,
+    date,
+    content,
+    shareText,
+    isPlaceholder,
+  }: {
+    title: string
+    date: string
+    content: string
+    shareText: string
+    isPlaceholder?: boolean
+  }) {
+    return (
+      <div className="bg-white/80 p-6 rounded-xl shadow-md space-y-4">
+        <h2 className="text-2xl text-rose-700 font-semibold">{title}</h2>
+        <p className="text-sm text-rose-500">{date}</p>
+        <p
+          className={
+            isPlaceholder
+              ? 'italic text-rose-600'
+              : 'whitespace-pre-line leading-relaxed'
+          }
+        >
+          {content}
+        </p>
+        <ShareButtons text={shareText} />
+      </div>
+    )
+  }
+
   return (
     <div className="max-w-3xl mx-auto bg-gradient-to-br from-rose-50 via-pink-50 to-rose-100 p-8 rounded-2xl shadow-lg border border-rose-200 text-gray-800 font-serif space-y-12">
       <div className="text-center space-y-2">
@@ -72,28 +201,21 @@ Gihigugma tika pag-ayo, hangtod sa walay katapusan, baby—karon, kanunay, ug ha
           {isBisaya ? 'Translate to English' : 'Translate to Bisaya'}
         </button>
       </div>
-      <div className="space-y-4">
-        <h2 className="text-2xl text-rose-700 font-semibold">
-          {isBisaya ? 'Panumpa ni Rumi' : "Rumi's Vow"}
-        </h2>
-        <p className="text-sm text-rose-500">
-          {isBisaya ? rumiDateBisaya : rumiDateEnglish}
-        </p>
-        <p className="whitespace-pre-line leading-relaxed">
-          {isBisaya ? rumiVowBisaya : rumiVowEnglish}
-        </p>
-      </div>
-      <div className="space-y-4">
-        <h2 className="text-2xl text-rose-700 font-semibold">
-          {isBisaya ? 'Panumpa ni Khen' : "Khen's Vow"}
-        </h2>
-        <p className="text-sm text-rose-500">
-          {isBisaya ? khenDateBisaya : khenDateEnglish}
-        </p>
-        <p className="italic text-rose-600">
-          {isBisaya ? khenPlaceholderBisaya : khenPlaceholderEnglish}
-        </p>
-      </div>
+      <VowCard
+        title={isBisaya ? 'Panumpa ni Rumi' : "Rumi's Vow"}
+        date={isBisaya ? rumiDateBisaya : rumiDateEnglish}
+        content={isBisaya ? rumiVowBisaya : rumiVowEnglish}
+        shareText={isBisaya ? rumiVowBisaya : rumiVowEnglish}
+      />
+      <VowCard
+        title={isBisaya ? 'Panumpa ni Khen' : "Khen's Vow"}
+        date={isBisaya ? khenDateBisaya : khenDateEnglish}
+        content={isBisaya ? khenPlaceholderBisaya : khenPlaceholderEnglish}
+        shareText={
+          isBisaya ? khenPlaceholderBisaya : khenPlaceholderEnglish
+        }
+        isPlaceholder
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add share buttons to Wedding Vows module supporting native share, Facebook, X, LinkedIn, WhatsApp, Telegram, and copy link
- render each vow in a styled card beneath a translation toggle
- document Wedding Vows sharing capability in TODO and CHANGELOG

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acbd3644b48327b6657042da7dbcf4