### PR TITLE
Retry grocery schema creation when table missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ All notable changes to **ZenzaScheduler OS Life Scheduler** are documented in th
 - IDE plus button opens a Harold and the Purple Crayon & Vanilla Sky filename window, and double-click renaming uses the same modal instead of a browser prompt (2025-08-02 02:49 UTC)
 - Learning Notes heading and cards darkened for higher contrast and easier reading (2025-08-21 22:11 UTC)
 ### Fixed
+- Grocery list module retries schema creation when the table is missing so lists load without relation errors (2025-08-26 19:00:51 UTC)
 - World Clock timezone search dropdown now appears above widgets so options aren't hidden when adding new zones (2025-08-22 17:10 UTC)
 - Removed call to failing `ensure-learning-notes-schema` Supabase function to avoid CORS errors during Learning Notes load (2025-08-22 15:52 UTC)
 - Learning Notes cards no longer render white text on white backgrounds by moving custom classes into the Tailwind components layer (2025-08-21 21:34:43 UTC)

--- a/TODO.md
+++ b/TODO.md
@@ -25,6 +25,7 @@ ZenzaScheduler OS — TODO
 - Soundboard default beep and chime download from the web instead of shipping audio files
 - Soundboard expanded to a 12-pad grid with keyboard shortcuts and removable custom clips
 - Removed missing ensure-todo-status Supabase function call to prevent CORS errors on to-do list load
+- Grocery lists retry schema creation when the table is missing so relation errors no longer appear
 - Added English/Bisaya translation toggle for Wedding Vows module
 - Displayed wedding vow writing date in Wedding Vows module
 - Showed Rumi's vow writing date and kept Khen's to be revealed

--- a/zenzalife-scheduler/public/CHANGELOG.md
+++ b/zenzalife-scheduler/public/CHANGELOG.md
@@ -71,6 +71,7 @@ All notable changes to **ZenzaScheduler OS Life Scheduler** are documented in th
 - IDE plus button opens a Harold and the Purple Crayon & Vanilla Sky filename window, and double-click renaming uses the same modal instead of a browser prompt (2025-08-02 02:49 UTC)
 - Learning Notes heading and cards darkened for higher contrast and easier reading (2025-08-21 22:11 UTC)
 ### Fixed
+- Grocery list module retries schema creation when the table is missing so lists load without relation errors (2025-08-26 19:00:51 UTC)
 - World Clock timezone search dropdown now appears above widgets so options aren't hidden when adding new zones (2025-08-22 17:10 UTC)
 - Removed call to failing `ensure-learning-notes-schema` Supabase function to avoid CORS errors during Learning Notes load (2025-08-22 15:52 UTC)
 - Learning Notes cards no longer render white text on white backgrounds by moving custom classes into the Tailwind components layer (2025-08-21 21:34:43 UTC)

--- a/zenzalife-scheduler/src/components/dashboard/GroceryListModule.tsx
+++ b/zenzalife-scheduler/src/components/dashboard/GroceryListModule.tsx
@@ -31,7 +31,7 @@ export function GroceryListModule() {
     }
   }, [user, selectedList])
 
-  const loadLists = async () => {
+  const loadLists = async (retry = true) => {
     if (!user) return
     const { data, error } = await supabase
       .from('grocery_lists')
@@ -40,6 +40,19 @@ export function GroceryListModule() {
       .order('list_date', { ascending: false })
       .order('created_at', { ascending: false })
     if (error) {
+      if (error.code === '42P01' && retry) {
+        try {
+          const { error: ensureError } = await supabase.functions.invoke(
+            'ensure-grocery-schema'
+          )
+          if (!ensureError) {
+            return await loadLists(false)
+          }
+          console.error('Failed to ensure grocery schema', ensureError)
+        } catch (err) {
+          console.error('Failed to ensure grocery schema', err)
+        }
+      }
       toast.error('Failed to load lists: ' + error.message)
     } else {
       setLists(data || [])
@@ -66,7 +79,10 @@ export function GroceryListModule() {
 
   const initialize = async () => {
     try {
-      await supabase.functions.invoke('ensure-grocery-schema')
+      const { error } = await supabase.functions.invoke('ensure-grocery-schema')
+      if (error) {
+        console.error('Failed to ensure grocery schema', error)
+      }
     } catch (err) {
       console.error('Failed to ensure grocery schema', err)
     }


### PR DESCRIPTION
## Summary
- Retry grocery schema creation when the `grocery_lists` table is missing so lists load without relation errors
- Note the automatic retry in TODO and changelog entries

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae038c390c8327a4b57a902ab41b71